### PR TITLE
Corrected necessity for -fpermissive when building this with gcc 4.7+. G...

### DIFF
--- a/libsrc/cpp/bulkio_out_port.cpp
+++ b/libsrc/cpp/bulkio_out_port.cpp
@@ -130,7 +130,7 @@ namespace  bulkio {
 
     if (refreshSRI) {
       if (currentSRIs.find(streamID) != currentSRIs.end()) {
-	pushSRI(currentSRIs[streamID].first);
+	this->pushSRI(currentSRIs[streamID].first);
       }
     }
     SCOPED_LOCK lock(updatingPortsLock);   
@@ -170,7 +170,7 @@ namespace  bulkio {
 
     if (refreshSRI) {
       if (currentSRIs.find(streamID) != currentSRIs.end()) {
-	pushSRI(currentSRIs[streamID].first);
+	this->pushSRI(currentSRIs[streamID].first);
       }
     }
     SCOPED_LOCK lock(updatingPortsLock);   // don't want to process while command information is coming in
@@ -463,7 +463,7 @@ namespace  bulkio {
 
     if (this->refreshSRI) {
       if (this->currentSRIs.find(streamID) != this->currentSRIs.end()) {
-	pushSRI(this->currentSRIs[streamID].first);
+	this->pushSRI(this->currentSRIs[streamID].first);
       }
     }
     SCOPED_LOCK lock(this->updatingPortsLock);   // don't want to process while command information is coming in
@@ -502,7 +502,7 @@ namespace  bulkio {
 
     if (this->refreshSRI) {
       if (this->currentSRIs.find(streamID) != this->currentSRIs.end()) {
-	pushSRI(this->currentSRIs[streamID].first);
+	this->pushSRI(this->currentSRIs[streamID].first);
       }
     }
     SCOPED_LOCK lock(this->updatingPortsLock);   // don't want to process while command information is coming in
@@ -541,7 +541,7 @@ namespace  bulkio {
     TRACE_ENTER(this->logger, "OutStringPort::pushPacket" );
     if (this->refreshSRI) {
       if (this->currentSRIs.find(streamID) != this->currentSRIs.end()) {
-	pushSRI(this->currentSRIs[streamID].first);
+	this->pushSRI(this->currentSRIs[streamID].first);
       }
     }
     SCOPED_LOCK lock(this->updatingPortsLock);   // don't want to process while command information is coming in
@@ -574,7 +574,7 @@ namespace  bulkio {
     TRACE_ENTER(this->logger, "OutStringPort::pushPacket" );
     if (this->refreshSRI) {
       if (this->currentSRIs.find(streamID) != this->currentSRIs.end()) {
-	pushSRI(this->currentSRIs[streamID].first);
+	this->pushSRI(this->currentSRIs[streamID].first);
       }
     }
     SCOPED_LOCK lock(this->updatingPortsLock);   // don't want to process while command information is coming in


### PR DESCRIPTION
The following patch corrects errors when building using gcc 4.7+. GCC no longer performs the extra unqualified lookups for base class scope or unqualifed template function lookups preformed in the past. See http://gcc.gnu.org/gcc-4.7/porting_to.html. The solution is to explicitly call this-> before pushSRI.

The error is :
cpp/bulkio_out_port.cpp:466:27: warning: 'bulkio::OutPort<bulkio::PortTraits<POA_BULKIO::dataFile, BULKIO::dataFile, bulkio::DataTransferTraits<char*, char, char, std::basic_string<char> > > >::currentSRIs' is deprecated (declared at ./cpp/bulkio_out_port.h:329) [-Wdeprecated-declarations] 
  pushSRI(this->currentSRIs[streamID].first); 
                           ^ 
cpp/bulkio_out_port.cpp:466:27: warning: 'bulkio::OutPort<bulkio::PortTraits<POA_BULKIO::dataFile, BULKIO::dataFile, bulkio::DataTransferTraits<char*, char, char, std::basic_string<char> > > >::currentSRIs' is deprecated (declared at ./cpp/bulkio_out_port.h:329) [-Wdeprecated-declarations] 
cpp/bulkio_out_port.cpp:466:43: error: 'pushSRI' was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive] 
  pushSRI(this->currentSRIs[streamID].first); 
                                           ^ 
cpp/bulkio_out_port.cpp:466:43: note: declarations in dependent base 'bulkio::OutPort<bulkio::PortTraits<POA_BULKIO::dataFile, BULKIO::dataFile, bulkio::DataTransferTraits<char*, char, char, std::basic_string<char> > > >' are not found by unqualified lookup 
cpp/bulkio_out_port.cpp:466:43: note: use 'this->pushSRI' instead
